### PR TITLE
Fixed Subject Consent + GA Delivery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 ./.vscode
+**/.idea/**
+
+# migrations
+**./migrations/**
+**./flourish_caregiver/migrations/**

--- a/flourish_caregiver/admin/subject_consent_admin.py
+++ b/flourish_caregiver/admin/subject_consent_admin.py
@@ -115,6 +115,7 @@ class CaregiverChildConsentInline(StackedInlineMixin, ModelAdminFormAutoNumberMi
 
     def get_extra(self, request, obj=None, **kwargs):
         extra = super().get_extra(request, obj, **kwargs)
+        breakpoint()
         study_maternal_id = request.GET.get('study_maternal_identifier')
         subject_identifier = request.GET.get('subject_identifier')
 
@@ -124,7 +125,7 @@ class CaregiverChildConsentInline(StackedInlineMixin, ModelAdminFormAutoNumberMi
             if not obj:
                 extra = caregiver_child_consents.count()
 
-        if study_maternal_id:
+        elif study_maternal_id:
             child_datasets = self.child_dataset_cls.objects.filter(
                 study_maternal_identifier=study_maternal_id)
             if not obj:

--- a/flourish_caregiver/admin/subject_consent_admin.py
+++ b/flourish_caregiver/admin/subject_consent_admin.py
@@ -115,7 +115,6 @@ class CaregiverChildConsentInline(StackedInlineMixin, ModelAdminFormAutoNumberMi
 
     def get_extra(self, request, obj=None, **kwargs):
         extra = super().get_extra(request, obj, **kwargs)
-        breakpoint()
         study_maternal_id = request.GET.get('study_maternal_identifier')
         subject_identifier = request.GET.get('subject_identifier')
 

--- a/flourish_caregiver/models/antenatal_enrollment.py
+++ b/flourish_caregiver/models/antenatal_enrollment.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 from edc_base.model_managers import HistoricalRecords
@@ -8,11 +6,12 @@ from edc_base.model_validators import date_not_future
 from edc_constants.choices import YES_NO
 from edc_identifier.model_mixins import UniqueSubjectIdentifierFieldMixin
 from edc_protocol.validators import date_not_before_study_start
+from edc_base.utils import get_utcnow
 
 from .enrollment_mixin import EnrollmentMixin
 from .maternal_delivery import MaternalDelivery
 from ..helper_classes import EnrollmentHelper
-from edc_base.utils import get_utcnow
+
 class AntenatalEnrollment(UniqueSubjectIdentifierFieldMixin,
                           EnrollmentMixin, BaseUuidModel):
 

--- a/flourish_caregiver/models/antenatal_enrollment.py
+++ b/flourish_caregiver/models/antenatal_enrollment.py
@@ -70,7 +70,7 @@ class AntenatalEnrollment(UniqueSubjectIdentifierFieldMixin,
         else:
             # if MaternalDelivery object exist, it means the mother delivered
             # hence no need for changine ga
-            ga_weeks = enrollment_helper.evaluate_ga_lmp(delivery.report_datetime.date())
+            ga_weeks = enrollment_helper.evaluate_ga_lmp(delivery.delivery_datetime.date())
 
         return ga_weeks
 

--- a/flourish_caregiver/models/antenatal_enrollment.py
+++ b/flourish_caregiver/models/antenatal_enrollment.py
@@ -12,6 +12,7 @@ from edc_protocol.validators import date_not_before_study_start
 from .enrollment_mixin import EnrollmentMixin
 from .maternal_delivery import MaternalDelivery
 from ..helper_classes import EnrollmentHelper
+from edc_base.utils import get_utcnow
 class AntenatalEnrollment(UniqueSubjectIdentifierFieldMixin,
                           EnrollmentMixin, BaseUuidModel):
 
@@ -65,7 +66,7 @@ class AntenatalEnrollment(UniqueSubjectIdentifierFieldMixin,
                 subject_identifier=self.subject_identifier)
         except MaternalDelivery.DoesNotExist:
             # if means the mother haven't given birth just yet
-            today = datetime.date.today()# to allow date to increment
+            today = get_utcnow().date() # to allow date to increment
             ga_weeks = enrollment_helper.evaluate_ga_lmp(today) # get ga using the enrollment helper
         else:
             # if MaternalDelivery object exist, it means the mother delivered


### PR DESCRIPTION
- Subject consent for mothers with 2 siblings was not being prepolated
- GA now using delivery date instead of report_datetime