### PR TITLE
Update radio_fields in hits_screening_admin.py



### DIFF
--- a/flourish_caregiver/admin/hits_screening_admin.py
+++ b/flourish_caregiver/admin/hits_screening_admin.py
@@ -27,6 +27,7 @@ class HITSScreeningAdmin(CrfModelAdminMixin, admin.ModelAdmin):
     )
 
     radio_fields = {
+        'in_relationship': admin.VERTICAL,
         'physical_hurt': admin.VERTICAL,
         'insults': admin.VERTICAL,
         'threaten': admin.VERTICAL,


### PR DESCRIPTION
A new field 'in_relationship' has been added to the radio_fields dictionary in hits_screening_admin.py. This addition ensures 'in_relationship' field is properly displayed in the admin UI, making it user-friendly and functional.