### PR TITLE
Initialize hit score before calculation in hits_screening.py

### DIFF
--- a/flourish_caregiver/models/hits_screening.py
+++ b/flourish_caregiver/models/hits_screening.py
@@ -46,6 +46,7 @@ class HITSScreening(CrfModelMixin):
         max_length=5)
 
     def save(self, *args, **kwargs):
+        self.score = 0
         if self.in_relationship == YES:
             self.score = (int(self.physical_hurt) + int(self.insults) +
                           int(self.threaten) + int(self.screem_curse))


### PR DESCRIPTION
In the hits_screening.py model, the hit score is now initialized to zero in the save method. The change ensures that the score is only calculated if the participant is in a relationship, thereby optimizing computations and preventing potential TypeErrors due to missing attributes.