### PR TITLE
(refactor): Add special instructions to templates and admin

### DIFF
--- a/flourish_caregiver/admin/interview_focus_group_interest_admin.py
+++ b/flourish_caregiver/admin/interview_focus_group_interest_admin.py
@@ -13,14 +13,6 @@ class InterviewFocusGroupInterestAdmin(CrfModelAdminMixin, admin.ModelAdmin):
 
     instructions = ''
 
-    additional_instructions = (
-        'The questions I will ask are designed solely for data collection purposes and '
-        'the purpose of these questions is to explore your topic of interest for '
-        'discussion in case we are to have interviews or focus group settings, '
-        'in our future studies. At this time, there are no ongoing or upcoming studies '
-        'to address these interests however, your responses will help to identify '
-        'future study topics. ')
-
     fieldsets = (
         (
             None, {
@@ -89,3 +81,16 @@ class InterviewFocusGroupInterestAdmin(CrfModelAdminMixin, admin.ModelAdmin):
     }
 
     search_fields = ('subject_identifier',)
+
+    def add_view(self, request, form_url='', extra_context=None):
+        extra_context = extra_context or {}
+
+        extra_context['special_instructions'] = (
+            '***INSTRUCTIONS CLINIC STAFF: The questions I will ask are designed solely'
+            ' for data collection purposes and the purpose of these questions is to '
+            'explore your topic of interest for discussion in case we are to have '
+            'interviews or focus group settings, in our future studies. At this time, '
+            'there are no ongoing or upcoming studies to address these interests '
+            'however, your responses will help to identify future study topics. ')
+
+        return super().add_view(request, form_url, extra_context)

--- a/flourish_caregiver/templates/admin/flourish_caregiver/change_form.html
+++ b/flourish_caregiver/templates/admin/flourish_caregiver/change_form.html
@@ -41,6 +41,9 @@
         </div>
         <br>
     {% endif %}
+    {% if special_instructions %}
+    <p><b>{{ special_instructions|safe }}</b></p>
+    {% endif %}
     {{ block.super }}
 {% endblock field_sets %}
 


### PR DESCRIPTION
Moved the special instructions from being hardcoded directly within the admin classes to the corresponding templates. Added instructions within the `add_view` method in admin for consistency. Affected classes include `InterviewFocusGroupInterestAdmin`, `ChildFoodSecurityQuestionnaireAdmin`, and `AcademicPerformanceAdmin`. Signed-off-by: nmunatsibw 