### PR TITLE
(refactor): Update model and constants import order


### DIFF
--- a/flourish_caregiver/models/cohort.py
+++ b/flourish_caregiver/models/cohort.py
@@ -6,12 +6,12 @@ from edc_base.model_validators import datetime_not_future
 from edc_base.sites import SiteModelMixin
 from edc_base.utils import get_utcnow
 from edc_constants.choices import YES_NO
-from edc_constants.constants import POS, NEG
+from edc_constants.constants import NEG, POS
 from edc_identifier.model_mixins import NonUniqueSubjectIdentifierFieldMixin
 from edc_protocol.validators import datetime_not_before_study_start
 
 from .caregiver_child_consent import CaregiverChildConsent
-from .model_mixins import SearchSlugModelMixin, MatrixMatchVariablesMixin
+from .model_mixins import MatrixMatchVariablesMixin, SearchSlugModelMixin
 from ..helper_classes import MaternalStatusHelper
 from ..helper_classes.schedule_dict import child_schedule_dict
 
@@ -54,7 +54,6 @@ class Cohort(MatrixMatchVariablesMixin,
         self.exposure_status = self.check_exposure()
         self.current_cohort = self.check_current_cohort()
         super().save(*args, **kwargs)
-        
 
     @property
     def schedule_history_cls(self):
@@ -79,7 +78,7 @@ class Cohort(MatrixMatchVariablesMixin,
         antenatal = antenatal_cls.objects.filter(
             subject_identifier=self.caregiver_subject_identifier)
         return antenatal.exists()
-        
+
     def check_exposure(self):
         exposure = {POS: 'EXPOSED', NEG: 'UNEXPOSED', }
         child_dataset = getattr(self.caregiver_child_consent, 'child_dataset', None)
@@ -93,13 +92,16 @@ class Cohort(MatrixMatchVariablesMixin,
     def check_current_cohort(self):
         cohort_onschedules = [name_dict.get('name') for name_dict in
                               child_schedule_dict.get(self.name).values()]
+
+        ignore_schedule = ['tb_adol', 'child_bu', 'facet']
         try:
             latest_onschedule = self.schedule_history_cls.objects.filter(
                 subject_identifier=self.subject_identifier, ).exclude(
-                    schedule_name__icontains='tb_adol').latest('onschedule_datetime', 'created')
+                schedule_name__in=ignore_schedule).latest(
+                'onschedule_datetime', 'created')
         except self.schedule_history_cls.DoesNotExist:
             return self.check_antenetal_exists()
-        else:     
+        else:
             return getattr(latest_onschedule, 'schedule_name', None) in cohort_onschedules
 
     class Meta:

--- a/flourish_caregiver/models/cohort.py
+++ b/flourish_caregiver/models/cohort.py
@@ -93,7 +93,8 @@ class Cohort(MatrixMatchVariablesMixin,
         cohort_onschedules = [name_dict.get('name') for name_dict in
                               child_schedule_dict.get(self.name).values()]
 
-        ignore_schedule = ['tb_adol', 'child_bu', 'facet']
+        ignore_schedule = ['tb_adol_followup_schedule', 'tb_adol_schedule',
+                           'child_bu_schedule', 'child_facet_schedule']
         try:
             latest_onschedule = self.schedule_history_cls.objects.filter(
                 subject_identifier=self.subject_identifier, ).exclude(


### PR DESCRIPTION

This commit cleans up the import order in 'cohort.py' for better readability and also removes some extraneous whitespaces. A list of ignored schedule names is added to more specifically target the filtering process in 'check_current_cohort' function. The filtered result is now determined by checking if 'schedule_name' is in the ignored list, enhancing code clarity and maintainability. Signed-off-by: nmunatsibw 