### PR TITLE
(refactor): Set 'enrollment_cohort' field as read-only in Cohort Admin

### DIFF
--- a/flourish_caregiver/admin/cohort_admin.py
+++ b/flourish_caregiver/admin/cohort_admin.py
@@ -11,6 +11,7 @@ class CohortAdmin(ModelAdminMixin, admin.ModelAdmin):
 
     form = CohortForm
     search_fields = ['subject_identifier']
+    readonly_fields = ['enrollment_cohort']
 
     fields = ('name',
               'assign_datetime',


### PR DESCRIPTION
This commit makes the 'enrollment_cohort' field in the CohortForm to be read-only. This change is intended to avoid erroneous changes and preserve data integrity in the CohortForm admin interface.