### PR TITLE
(refactor): Update TB screening and referral tests



### DIFF
--- a/flourish_caregiver/admin/caregiver_tb_referral_outcome_admin.py
+++ b/flourish_caregiver/admin/caregiver_tb_referral_outcome_admin.py
@@ -41,6 +41,8 @@ class CaregiverTBReferralOutcomeAdmin(CrfModelAdminMixin, admin.ModelAdmin):
             ]}
          ), audit_fieldset_tuple)
 
+    filter_horizontal = ('tests_performed',)
+
     radio_fields = {'tb_evaluation': admin.VERTICAL,
                     'clinic_name': admin.VERTICAL,
                     'chest_xray_results': admin.VERTICAL,

--- a/flourish_caregiver/choices.py
+++ b/flourish_caregiver/choices.py
@@ -1209,7 +1209,7 @@ TB_REASON_CHOICES = (
     ('work', 'Participant/caregiver cannot be released from work'),
     ('isolation', 'Participant is in isolation due to COVID-19 or another infection'),
     ('not_well', 'Participant/caregiver is not well'),
-    ('other', 'Other'),
+    (OTHER, 'Other'),
 )
 
 PERIOD_HAPPENED = (

--- a/flourish_caregiver/helper_classes/tb_diagnosis.py
+++ b/flourish_caregiver/helper_classes/tb_diagnosis.py
@@ -1,4 +1,4 @@
-from edc_constants.constants import NO, POS, YES
+from edc_constants.constants import NEG, NO, POS, YES
 
 
 class TBDiagnosis:
@@ -20,7 +20,7 @@ class TBDiagnosis:
                              screening.sweats_duration == '>= 2 weeks',
                              screening.weight_loss_duration == '>= 2 weeks',
                              screening.evaluated_for_tb == NO]) >= 1)
-        if self.hiv_status == POS:
+        if self.hiv_status == NEG:
             return (sum([screening.cough_duration == '>= 2 weeks',
                          screening.fever_duration == '>= 2 weeks',
                          screening.sweats_duration == '>= 2 weeks',

--- a/flourish_caregiver/helper_classes/tb_diagnosis.py
+++ b/flourish_caregiver/helper_classes/tb_diagnosis.py
@@ -1,0 +1,34 @@
+from edc_constants.constants import NO, POS, YES
+
+
+class TBDiagnosis:
+    def __init__(self, child_age=None, hiv_status=None):
+        self.child_age = child_age
+        self.hiv_status = hiv_status
+
+    def evaluate_for_tb(self, screening):
+        if self.child_age:
+            if self.child_age <= 12:
+                return (screening.evaluated_for_tb == NO or sum(
+                    [screening.cough_duration == '>= 2 weeks',
+                     screening.fever_duration == '>= 2 weeks',
+                     screening.weight_loss_duration == '>= 2 weeks',
+                     screening.fatigue_or_reduced_playfulness == YES]) >= 2)
+            elif self.child_age > 12:
+                return (sum([screening.cough_duration == '>= 2 weeks',
+                             screening.fever_duration == '>= 2 weeks',
+                             screening.sweats_duration == '>= 2 weeks',
+                             screening.weight_loss_duration == '>= 2 weeks',
+                             screening.evaluated_for_tb == NO]) >= 1)
+        if self.hiv_status == POS:
+            return (sum([screening.cough_duration == '>= 2 weeks',
+                         screening.fever_duration == '>= 2 weeks',
+                         screening.sweats_duration == '>= 2 weeks',
+                         screening.weight_loss_duration == '>= 2 weeks',
+                         screening.evaluated_for_tb == NO]) >= 1)
+        else:
+            return (sum([screening.cough == YES,
+                         screening.fever == YES,
+                         screening.sweats == YES,
+                         screening.weight_loss == YES,
+                         screening.evaluated_for_tb == NO]) >= 1)

--- a/flourish_caregiver/models/caregiver_tb_screening.py
+++ b/flourish_caregiver/models/caregiver_tb_screening.py
@@ -2,13 +2,14 @@ from django.db import models
 from edc_base.model_mixins import BaseUuidModel
 from edc_constants.choices import YES_NO
 
+from flourish_caregiver.helper_classes import MaternalStatusHelper
+from flourish_caregiver.helper_classes.tb_diagnosis import TBDiagnosis
 from flourish_caregiver.models.model_mixins import CrfModelMixin
 from flourish_caregiver.models.model_mixins.flourish_tb_screening_mixin import \
     TBScreeningMixin
 
 
 class CaregiverTBScreening(CrfModelMixin, TBScreeningMixin):
-
     diagnosed_with_TB = models.CharField(
         verbose_name='Were you diagnosed with TB?',
         choices=YES_NO,
@@ -21,6 +22,14 @@ class CaregiverTBScreening(CrfModelMixin, TBScreeningMixin):
         verbose_name='Were you started on TB preventative therapy?',
         choices=YES_NO,
         max_length=3)
+
+    def save(self, *args, **kwargs):
+        maternal_status_helper = MaternalStatusHelper(maternal_visit=self.maternal_visit)
+        tb_diagnoses = TBDiagnosis(hiv_status=maternal_status_helper.hiv_status)
+
+        self.tb_diagnoses = tb_diagnoses.evaluate_for_tb(self)
+
+        super().save(*args, **kwargs)
 
     class Meta(BaseUuidModel.Meta):
         app_label = 'flourish_caregiver'

--- a/flourish_caregiver/models/model_mixins/flourish_tb_screening_mixin.py
+++ b/flourish_caregiver/models/model_mixins/flourish_tb_screening_mixin.py
@@ -68,6 +68,7 @@ class TBScreeningMixin(models.Model):
 
     tb_tests = models.ManyToManyField(
         TBTests,
+        blank=True,
         verbose_name='What diagnostic tests were performed for TB?',
         max_length=15, )
 
@@ -101,6 +102,11 @@ class TBScreeningMixin(models.Model):
 
     other_test_results = models.TextField(verbose_name='Other Test Result', blank=True,
                                           null=True)
+
+    tb_diagnoses = models.BooleanField(
+        blank=True,
+        null=True
+    )
 
     class Meta:
         abstract = True

--- a/flourish_caregiver/settings.py
+++ b/flourish_caregiver/settings.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = [
     'flourish_metadata_rules.apps.AppConfig',
     'flourish_child.apps.AppConfig',
     'flourish_facet.apps.AppConfig',
+    'flourish_export.apps.AppConfig',
     'pre_flourish.apps.AppConfig',
     'pre_flourish_follow.apps.AppConfig',
     'flourish_follow.apps.AppConfig',
@@ -102,7 +103,7 @@ ROOT_URLCONF = 'flourish_caregiver.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/flourish_caregiver/tests/test_tb_diagnosis.py
+++ b/flourish_caregiver/tests/test_tb_diagnosis.py
@@ -1,0 +1,52 @@
+from django.test import TestCase, tag
+from edc_constants.constants import NEG, NO, POS, YES
+
+from flourish_caregiver.helper_classes.tb_diagnosis import TBDiagnosis
+
+
+@tag('tbdia')
+class TestTBDiagnosis(TestCase):
+    def setUp(self):
+        self.child_age = None
+        self.hiv_status = None
+        self.tb_diagnosis = TBDiagnosis(self.child_age, self.hiv_status)
+
+    def test_evaluate_for_tb_child_age_under_12(self):
+        self.tb_diagnosis.child_age = 10
+        screening = lambda: None
+        screening.evaluated_for_tb = NO
+        screening.cough_duration = '>= 2 weeks'
+        screening.fever_duration = '< 2 weeks'
+        screening.weight_loss_duration = '< 2 weeks'
+        screening.fatigue_or_reduced_playfulness = NO
+        self.assertEqual(self.tb_diagnosis.evaluate_for_tb(screening), True)
+
+    def test_evaluate_for_tb_child_age_over_12(self):
+        self.tb_diagnosis.child_age = 13
+        screening = lambda: None
+        screening.cough_duration = '< 2 weeks'
+        screening.fever_duration = '< 2 weeks'
+        screening.weight_loss_duration = '< 2 weeks'
+        screening.sweats_duration = '< 2 weeks'
+        screening.evaluated_for_tb = YES
+        self.assertEqual(self.tb_diagnosis.evaluate_for_tb(screening), False)
+
+    def test_evaluate_for_tb_hiv_POS_caregiver(self):
+        self.tb_diagnosis.hiv_status = POS
+        screening = lambda: None
+        screening.cough_duration = '>= 2 weeks'
+        screening.fever_duration = '>= 2 weeks'
+        screening.weight_loss_duration = '>= 2 weeks'
+        screening.sweats_duration = '>= 2 weeks'
+        screening.evaluated_for_tb = YES
+        self.assertEqual(self.tb_diagnosis.evaluate_for_tb(screening), True)
+
+    def test_evaluate_for_tb_hiv_NEG_caregiver(self):
+        self.tb_diagnosis.hiv_status = NEG
+        screening = lambda: None
+        screening.cough = YES
+        screening.fever = NO
+        screening.sweats = YES
+        screening.weight_loss = YES
+        screening.evaluated_for_tb = YES
+        self.assertEqual(self.tb_diagnosis.evaluate_for_tb(screening), True)

--- a/flourish_caregiver/tests/test_tb_diagnosis.py
+++ b/flourish_caregiver/tests/test_tb_diagnosis.py
@@ -32,7 +32,7 @@ class TestTBDiagnosis(TestCase):
         self.assertEqual(self.tb_diagnosis.evaluate_for_tb(screening), False)
 
     def test_evaluate_for_tb_hiv_POS_caregiver(self):
-        self.tb_diagnosis.hiv_status = POS
+        self.tb_diagnosis.hiv_status = NEG
         screening = lambda: None
         screening.cough_duration = '>= 2 weeks'
         screening.fever_duration = '>= 2 weeks'
@@ -42,7 +42,7 @@ class TestTBDiagnosis(TestCase):
         self.assertEqual(self.tb_diagnosis.evaluate_for_tb(screening), True)
 
     def test_evaluate_for_tb_hiv_NEG_caregiver(self):
-        self.tb_diagnosis.hiv_status = NEG
+        self.tb_diagnosis.hiv_status = POS
         screening = lambda: None
         screening.cough = YES
         screening.fever = NO

--- a/flourish_caregiver/tests/test_tb_refferal_outcome.py
+++ b/flourish_caregiver/tests/test_tb_refferal_outcome.py
@@ -1,3 +1,4 @@
+from dateutil.relativedelta import relativedelta
 from django.test import tag, TestCase
 from edc_appointment.models import Appointment
 from edc_base import get_utcnow
@@ -16,48 +17,153 @@ class TestTBReferralOutcome(TestCase):
 
     def setUp(self):
         import_holidays()
-        self.subject_helper = SubjectHelperMixin()
+        self.subject_identifier = '12345678'
+        self.study_maternal_identifier = '89721'
 
-        self.subject_identifier = self.subject_helper.create_antenatal_enrollment(
-            version='3')
+        self.options = {
+            'consent_datetime': get_utcnow(),
+            'version': '4'}
 
-        self.caregiver_visit_1000M = mommy.make_recipe(
+        self.maternal_dataset_options = {
+            'delivdt': get_utcnow() - relativedelta(years=2, months=5),
+            'mom_enrolldate': get_utcnow(),
+            'mom_hivstatus': 'HIV-infected',
+            'study_maternal_identifier': self.study_maternal_identifier,
+            'protocol': 'Tshilo Dikotla'}
+
+        self.child_dataset_options = {
+            'infant_hiv_exposed': 'Exposed',
+            'infant_enrolldate': get_utcnow(),
+            'study_maternal_identifier': self.study_maternal_identifier,
+            'study_child_identifier': '1234'}
+
+        self.subject_identifier = self.subject_identifier[:-1] + '1'
+
+        self.maternal_dataset_obj = mommy.make_recipe(
+            'flourish_caregiver.maternaldataset',
+            subject_identifier=self.subject_identifier,
+            **self.maternal_dataset_options)
+
+        mommy.make_recipe(
+            'flourish_child.childdataset',
+            dob=get_utcnow() - relativedelta(years=2, months=5),
+            **self.child_dataset_options)
+
+        screening_obj = mommy.make_recipe(
+            'flourish_caregiver.screeningpriorbhpparticipants',
+            mother_alive=YES,
+            flourish_participation='interested')
+
+        self.subject_consent = mommy.make_recipe(
+            'flourish_caregiver.subjectconsent',
+            screening_identifier=screening_obj.screening_identifier,
+            breastfeed_intent=YES,
+            biological_caregiver=YES,
+            **self.options)
+
+        mommy.make_recipe(
+            'flourish_caregiver.caregiverchildconsent',
+            subject_consent=self.subject_consent,
+            study_child_identifier=self.child_dataset_options['study_child_identifier'],
+            child_dob=(get_utcnow() - relativedelta(years=4, months=5)).date(), )
+
+        mommy.make_recipe(
+            'flourish_caregiver.caregiverpreviouslyenrolled',
+            subject_identifier=self.subject_consent.subject_identifier)
+
+        self.caregiver_visit_2000M = mommy.make_recipe(
             'flourish_caregiver.maternalvisit',
             appointment=Appointment.objects.get(
-                visit_code='1000M',
-                subject_identifier=self.subject_identifier),
+                visit_code='2000M',
+                subject_identifier=self.subject_consent.subject_identifier),
             report_datetime=get_utcnow(),
             reason=SCHEDULED)
 
-    def test_tb_referral_outcome_required(self):
+    def test_tb_referral_hiv_pos_required(self):
         self.assertEqual(CrfMetadata.objects.get(
-            subject_identifier=self.subject_identifier,
-            model='flourish_caregiver.caregivertbreferraloutcome',
-            visit_code='1000M').entry_status, NOT_REQUIRED)
+            subject_identifier=self.subject_consent.subject_identifier,
+            model='flourish_caregiver.tbreferralcaregiver',
+            visit_code='2000M').entry_status, NOT_REQUIRED)
 
-        tb_referral_caregiver = mommy.make_recipe(
-            'flourish_caregiver.tbreferralcaregiver',
-            maternal_visit=self.caregiver_visit_1000M,
-            referred_for_screening=YES)
-        tb_referral_caregiver.save()
+        mommy.make_recipe(
+            'flourish_caregiver.caregivertbscreening',
+            maternal_visit=self.caregiver_visit_2000M,
+            cough=YES,
+            fever=YES,
+            sweats=YES, )
 
         self.assertEqual(CrfMetadata.objects.get(
-            subject_identifier=self.subject_identifier,
-            model='flourish_caregiver.caregivertbreferraloutcome',
-            visit_code='1000M').entry_status, REQUIRED)
+            subject_identifier=self.subject_consent.subject_identifier,
+            model='flourish_caregiver.tbreferralcaregiver',
+            visit_code='2000M').entry_status, REQUIRED)
 
-    def test_tb_referral_outcome_not_required(self):
+        caregiver_visit_2001M = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=Appointment.objects.get(
+                visit_code='2001M',
+                subject_identifier=self.subject_consent.subject_identifier),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
         self.assertEqual(CrfMetadata.objects.get(
-            subject_identifier=self.subject_identifier,
-            model='flourish_caregiver.caregivertbreferraloutcome',
+            subject_identifier=self.subject_consent.subject_identifier,
+            model='flourish_caregiver.tbreferralcaregiver',
+            visit_code='2001M').entry_status, NOT_REQUIRED)
+
+    @tag('gdsj')
+    def test_tb_referral_hiv_neg_required(self):
+        self.subject_helper = SubjectHelperMixin()
+
+        subject_identifier = self.subject_helper.create_antenatal_enrollment(
+            version='4')
+
+        caregiver_visit_1000M = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=Appointment.objects.get(
+                visit_code='1000M',
+                subject_identifier=subject_identifier),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        self.assertEqual(CrfMetadata.objects.get(
+            subject_identifier=subject_identifier,
+            model='flourish_caregiver.tbreferralcaregiver',
             visit_code='1000M').entry_status, NOT_REQUIRED)
 
         mommy.make_recipe(
-            'flourish_caregiver.tbreferralcaregiver',
-            maternal_visit=self.caregiver_visit_1000M,
-            referred_for_screening=NO)
+            'flourish_caregiver.caregivertbscreening',
+            maternal_visit=caregiver_visit_1000M,
+            cough_duration='>= 2 weeks',
+            fever_duration=NO,
+            sweats_duration=NO,
+            weight_loss_duration=NO,
+            evaluated_for_tb=NO, )
 
         self.assertEqual(CrfMetadata.objects.get(
-            subject_identifier=self.subject_identifier,
+            subject_identifier=subject_identifier,
+            model='flourish_caregiver.tbreferralcaregiver',
+            visit_code='1000M').entry_status, REQUIRED)
+
+    @tag('esra')
+    def test_tb_referral_outcome_required(self):
+        self.assertEqual(CrfMetadata.objects.get(
+            subject_identifier=self.subject_consent.subject_identifier,
             model='flourish_caregiver.caregivertbreferraloutcome',
-            visit_code='1000M').entry_status, NOT_REQUIRED)
+            visit_code='2000M').entry_status, NOT_REQUIRED)
+
+        tb_referral_caregiver = mommy.make_recipe(
+            'flourish_caregiver.tbreferralcaregiver',
+            maternal_visit=self.caregiver_visit_2000M, )
+
+        caregiver_visit_2001M = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=Appointment.objects.get(
+                visit_code='2001M',
+                subject_identifier=self.subject_consent.subject_identifier),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        self.assertEqual(CrfMetadata.objects.get(
+            subject_identifier=self.subject_consent.subject_identifier,
+            model='flourish_caregiver.caregivertbreferraloutcome',
+            visit_code='2001M').entry_status, REQUIRED)

--- a/flourish_caregiver/tests/test_tb_refferal_outcome.py
+++ b/flourish_caregiver/tests/test_tb_refferal_outcome.py
@@ -79,6 +79,7 @@ class TestTBReferralOutcome(TestCase):
             report_datetime=get_utcnow(),
             reason=SCHEDULED)
 
+    @tag('posr')
     def test_tb_referral_hiv_pos_required(self):
         self.assertEqual(CrfMetadata.objects.get(
             subject_identifier=self.subject_consent.subject_identifier,
@@ -88,6 +89,7 @@ class TestTBReferralOutcome(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.caregivertbscreening',
             maternal_visit=self.caregiver_visit_2000M,
+            cough_duration='>= 2 weeks',
             cough=YES,
             fever=YES,
             sweats=YES, )


### PR DESCRIPTION
Modified the TB screening and referral tests, singularizing their version and enhancing their condition checking functionality. A new helper class, TBDiagnosis, was also introduced to evaluate if TB test is needed based on child's age and HIV status. General cleanup and reorganization of tests have been performed. Signed-off-by: nmunatsibw 