### PR TITLE
(feat): Update HIV disclosure status form, model, and admin interface



### DIFF
--- a/flourish_caregiver/admin/hiv_disclosure_status_admin.py
+++ b/flourish_caregiver/admin/hiv_disclosure_status_admin.py
@@ -81,15 +81,6 @@ class HIVDisclosureStatusAdminA(HIVDisclosureStatusAdminMixin,
 
         return super().add_view(request, form_url, extra_context)
 
-    def changeform_view(self, request, object_id=None, form_url='',
-                        extra_context=None):
-        g = request.GET.copy()
-        g.update({
-            'associated_child_identifier': self.child_gt10(request),
-        })
-        request.GET = g
-        return super().changeform_view(request, object_id, form_url, extra_context)
-
 
 @admin.register(HIVDisclosureStatusB, site=flourish_caregiver_admin)
 class HIVDisclosureStatusAdminB(HIVDisclosureStatusAdminMixin,
@@ -113,18 +104,6 @@ class HIVDisclosureStatusAdminB(HIVDisclosureStatusAdminMixin,
 
         return super().add_view(request, form_url, extra_context)
 
-    def change_view(self, request, object_id, form_url='', extra_context=None):
-        g = request.GET.copy()
-        breakpoint()
-        g.update({
-            'associated_child_identifier': object_id.associated_child_identifier,
-        })
-
-        request.GET = g
-
-        return super().change_view(
-            request, object_id, form_url=form_url, extra_context=extra_context)
-
 
 @admin.register(HIVDisclosureStatusC, site=flourish_caregiver_admin)
 class HIVDisclosureStatusAdminC(HIVDisclosureStatusAdminMixin,
@@ -147,14 +126,3 @@ class HIVDisclosureStatusAdminC(HIVDisclosureStatusAdminMixin,
         request.GET = g
 
         return super().add_view(request, form_url, extra_context)
-
-    def change_view(self, request, object_id, form_url='', extra_context=None):
-        g = request.GET.copy()
-        g.update({
-            'associated_child_identifier': object_id.associated_child_identifier,
-        })
-
-        request.GET = g
-
-        return super().change_view(
-            request, object_id, form_url=form_url, extra_context=extra_context)

--- a/flourish_caregiver/admin/hiv_disclosure_status_admin.py
+++ b/flourish_caregiver/admin/hiv_disclosure_status_admin.py
@@ -1,8 +1,8 @@
 from django.apps import apps as django_apps
 from django.contrib import admin
 from edc_model_admin import audit_fieldset_tuple
-from .modeladmin_mixins import CrfModelAdminMixin
 
+from .modeladmin_mixins import CrfModelAdminMixin
 from ..admin_site import flourish_caregiver_admin
 from ..forms import HIVDisclosureStatusFormA, HIVDisclosureStatusFormB
 from ..forms import HIVDisclosureStatusFormC
@@ -11,7 +11,6 @@ from ..models import HIVDisclosureStatusC
 
 
 class HIVDisclosureStatusAdminMixin(CrfModelAdminMixin, admin.ModelAdmin):
-
     fieldsets = (
         (None, {
             'fields': [
@@ -28,6 +27,9 @@ class HIVDisclosureStatusAdminMixin(CrfModelAdminMixin, admin.ModelAdmin):
                 'disclosure_difficulty',
                 'child_reaction',
                 'child_reaction_other',
+                'disclosure_intentional',
+                'unintentional_disclosure_reason',
+                'unintentional_disclosure_other',
             ]}
          ), audit_fieldset_tuple)
 
@@ -36,7 +38,11 @@ class HIVDisclosureStatusAdminMixin(CrfModelAdminMixin, admin.ModelAdmin):
                     'who_disclosed': admin.VERTICAL,
                     'disclosure_difficulty': admin.VERTICAL,
                     'child_reaction': admin.VERTICAL,
+                    'disclosure_intentional': admin.VERTICAL,
                     'plan_to_disclose': admin.VERTICAL}
+
+
+    filter_horizontal = ('unintentional_disclosure_reason',)
 
     def child_gt10(self, request):
         try:
@@ -61,11 +67,9 @@ class HIVDisclosureStatusAdminMixin(CrfModelAdminMixin, admin.ModelAdmin):
 @admin.register(HIVDisclosureStatusA, site=flourish_caregiver_admin)
 class HIVDisclosureStatusAdminA(HIVDisclosureStatusAdminMixin,
                                 admin.ModelAdmin):
-
     form = HIVDisclosureStatusFormA
 
     def add_view(self, request, form_url='', extra_context=None):
-
         associated_child_identifier = self.child_gt10(request)
 
         g = request.GET.copy()
@@ -77,6 +81,15 @@ class HIVDisclosureStatusAdminA(HIVDisclosureStatusAdminMixin,
 
         return super().add_view(request, form_url, extra_context)
 
+    def changeform_view(self, request, object_id=None, form_url='',
+                        extra_context=None):
+        g = request.GET.copy()
+        g.update({
+            'associated_child_identifier': self.child_gt10(request),
+        })
+        request.GET = g
+        return super().changeform_view(request, object_id, form_url, extra_context)
+
 
 @admin.register(HIVDisclosureStatusB, site=flourish_caregiver_admin)
 class HIVDisclosureStatusAdminB(HIVDisclosureStatusAdminMixin,
@@ -84,7 +97,6 @@ class HIVDisclosureStatusAdminB(HIVDisclosureStatusAdminMixin,
     form = HIVDisclosureStatusFormB
 
     def add_view(self, request, form_url='', extra_context=None):
-
         associated_child_identifier = self.child_gt10(request)
 
         if associated_child_identifier:
@@ -100,6 +112,18 @@ class HIVDisclosureStatusAdminB(HIVDisclosureStatusAdminMixin,
         request.GET = g
 
         return super().add_view(request, form_url, extra_context)
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        g = request.GET.copy()
+        breakpoint()
+        g.update({
+            'associated_child_identifier': object_id.associated_child_identifier,
+        })
+
+        request.GET = g
+
+        return super().change_view(
+            request, object_id, form_url=form_url, extra_context=extra_context)
 
 
 @admin.register(HIVDisclosureStatusC, site=flourish_caregiver_admin)
@@ -124,7 +148,13 @@ class HIVDisclosureStatusAdminC(HIVDisclosureStatusAdminMixin,
 
         return super().add_view(request, form_url, extra_context)
 
-# @admin.register(HIVDisclosureStatusD, site=flourish_caregiver_admin)
-# class HIVDisclosureStatusAdminD(HIVDisclosureStatusAdminMixin,
-        # admin.ModelAdmin):
-    # form = HIVDisclosureStatusFormD
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        g = request.GET.copy()
+        g.update({
+            'associated_child_identifier': object_id.associated_child_identifier,
+        })
+
+        request.GET = g
+
+        return super().change_view(
+            request, object_id, form_url=form_url, extra_context=extra_context)

--- a/flourish_caregiver/forms/hiv_disclosure_status_form.py
+++ b/flourish_caregiver/forms/hiv_disclosure_status_form.py
@@ -1,14 +1,22 @@
 from django import forms
 
-from ..models import HIVDisclosureStatusA, HIVDisclosureStatusB, HIVDisclosureStatusC
-from .form_mixins import SubjectModelFormMixin
-
 from flourish_form_validations.form_validators import HIVDisclosureStatusFormValidator
+from .form_mixins import SubjectModelFormMixin
+from ..models import HIVDisclosureStatusA, HIVDisclosureStatusB, HIVDisclosureStatusC
 
 
 class HIVDisclosureStatusFormMixin(SubjectModelFormMixin, forms.ModelForm):
-
     form_validator_cls = HIVDisclosureStatusFormValidator
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if 'initial' in kwargs:
+            self.fields['associated_child_identifier'].initial = kwargs['initial'].get(
+                'associated_child_identifier')
+        elif self.instance and self.instance.pk:
+            self.fields[
+                'associated_child_identifier'].initial = (
+                self.instance.associated_child_identifier)
 
     associated_child_identifier = forms.CharField(
         label='Associated child identifier',
@@ -19,7 +27,6 @@ class HIVDisclosureStatusFormMixin(SubjectModelFormMixin, forms.ModelForm):
 
 
 class HIVDisclosureStatusFormA(HIVDisclosureStatusFormMixin, forms.ModelForm):
-
     form_validator_cls = HIVDisclosureStatusFormValidator
 
     class Meta:
@@ -28,7 +35,6 @@ class HIVDisclosureStatusFormA(HIVDisclosureStatusFormMixin, forms.ModelForm):
 
 
 class HIVDisclosureStatusFormB(HIVDisclosureStatusFormMixin, forms.ModelForm):
-
     form_validator_cls = HIVDisclosureStatusFormValidator
 
     class Meta:
@@ -37,7 +43,6 @@ class HIVDisclosureStatusFormB(HIVDisclosureStatusFormMixin, forms.ModelForm):
 
 
 class HIVDisclosureStatusFormC(HIVDisclosureStatusFormMixin, forms.ModelForm):
-
     form_validator_cls = HIVDisclosureStatusFormValidator
 
     class Meta:

--- a/flourish_caregiver/forms/hiv_disclosure_status_form.py
+++ b/flourish_caregiver/forms/hiv_disclosure_status_form.py
@@ -8,16 +8,6 @@ from ..models import HIVDisclosureStatusA, HIVDisclosureStatusB, HIVDisclosureSt
 class HIVDisclosureStatusFormMixin(SubjectModelFormMixin, forms.ModelForm):
     form_validator_cls = HIVDisclosureStatusFormValidator
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if 'initial' in kwargs:
-            self.fields['associated_child_identifier'].initial = kwargs['initial'].get(
-                'associated_child_identifier')
-        elif self.instance and self.instance.pk:
-            self.fields[
-                'associated_child_identifier'].initial = (
-                self.instance.associated_child_identifier)
-
     associated_child_identifier = forms.CharField(
         label='Associated child identifier',
         widget=forms.TextInput(attrs={'readonly': 'readonly'}))

--- a/flourish_caregiver/list_data.py
+++ b/flourish_caregiver/list_data.py
@@ -429,11 +429,23 @@ list_data = {
     'flourish_caregiver.crackednipplesactions': [
         ('both_breasts', 'Breastfeed from both breasts'),
         ('non_cracked_breast',
-         'Breastfed from non-cracked nipple breast and pumped and dumped from the affected '
+         'Breastfed from non-cracked nipple breast and pumped and dumped from the '
+         'affected '
          'breast'),
         ('stopped_breastfeeding', 'Stopped breastfeeding and did not resume '),
         ('temp_stopped',
          'Stopped breastfeeding temporarily but resumed once breast healed'),
+        (OTHER, 'Other')
+    ],
+    'flourish_caregiver.disclosurereasons': [
+        ('someone_else_without_approval', 'Someone else disclosed without your approval'),
+        ('accidental_documentation',
+         'Child found out about status from accidentally seeing documentation/records'),
+        ('found_arv_medications',
+         'Child found out about status when they found ARV medications'),
+        ('overheard_conversation', 'Child overheard conversation about your HIV status'),
+        ('told_without_permission',
+         'Someone else told my child without my knowledge or permission'),
         (OTHER, 'Other')
     ]
 }

--- a/flourish_caregiver/models/hiv_disclosure_status.py
+++ b/flourish_caregiver/models/hiv_disclosure_status.py
@@ -3,6 +3,7 @@ from django.db import models
 from edc_base.model_fields import OtherCharField
 from edc_constants.choices import YES_NO
 
+from .list_models import DisclosureReasons
 from .model_mixins import CrfModelMixin
 from ..choices import DIFFICULTY_CHOICES, REACTION_CHOICES, REASONS_NOT_DISCLOSED, \
     WHODISCLOSED_CHOICES
@@ -69,6 +70,25 @@ class HIVDisclosureStatusMixin(CrfModelMixin):
         choices=REACTION_CHOICES)
 
     child_reaction_other = OtherCharField()
+
+    disclosure_intentional = models.CharField(
+        verbose_name='Did your child find out about your HIV status (disclosure) '
+                     'because you or another person you designated, intentionally told '
+                     'them?',
+        max_length=3,
+        default='',
+        choices=YES_NO, )
+
+    unintentional_disclosure_reason = models.ManyToManyField(
+        DisclosureReasons,
+        verbose_name='If this disclosure was unintentional, please provide reasons '
+                     'why:',
+        max_length=50,
+        blank=True, )
+
+    unintentional_disclosure_other = models.TextField(
+        blank=True,
+        null=True)
 
     class Meta(CrfModelMixin.Meta):
         abstract = True

--- a/flourish_caregiver/models/list_models.py
+++ b/flourish_caregiver/models/list_models.py
@@ -141,3 +141,7 @@ class MastitisActions(ListModelMixin, BaseUuidModel):
 
 class CrackedNipplesActions(ListModelMixin, BaseUuidModel):
     pass
+
+
+class DisclosureReasons(ListModelMixin, BaseUuidModel):
+    pass


### PR DESCRIPTION
The update implements additional fields and improved form management for the HIV disclosure status. Specific changes not only include the addition of new disclosure reasons to the 'list_data.py' and 'list_models.py', but it also encompasses modifications to the HIV disclosure form to handle the initial values for 'associated_child_identifier'. Further, updates were made to the HIV disclosure model to add new fields related to unintentional disclosure. Lastly, the admin interface was modified to handle the new fields and form improvements. Signed-off-by: nmunatsibw 