### PR TITLE
(refactor): Update list and model definitions

### DIFF
--- a/flourish_caregiver/admin/caregiver_tb_screening_admin.py
+++ b/flourish_caregiver/admin/caregiver_tb_screening_admin.py
@@ -36,8 +36,11 @@ class CaregiverTBScreeningAdmin(CrfModelAdminMixin, admin.ModelAdmin):
                 'blood_test_results',
                 'other_test_results',
                 'diagnosed_with_TB',
+                'diagnosed_with_TB_other',
                 'started_on_TB_treatment',
+                'started_on_TB_treatment_other',
                 'started_on_TB_preventative_therapy',
+                'started_on_TB_preventative_therapy_other',
             ]}),
         audit_fieldset_tuple
     )

--- a/flourish_caregiver/choices.py
+++ b/flourish_caregiver/choices.py
@@ -1311,6 +1311,13 @@ YES_NO_UKN_CHOICES = (
     (UNKNOWN, 'Unknown'),
 )
 
+YES_NO_AR_OTHER = (
+    (YES, YES),
+    (NO, NO),
+    (UNKNOWN, 'Awaiting results'),
+    (OTHER, 'Other'),
+)
+
 REFERRAL_LOCATION = (
     ('hospital_based_sw', 'Hospital-based Social Worker'),
     ('community_sw', 'Community Social Worker'),

--- a/flourish_caregiver/list_data.py
+++ b/flourish_caregiver/list_data.py
@@ -403,7 +403,7 @@ list_data = {
         ('urine_test', 'Urine test (LAM)'),
         ('skin_test', 'Skin test (TST/Mantoux)'),
         ('blood_test', 'Blood test (quantiferon)'),
-        ('None', 'None'),
+        (NONE, 'None'),
         (OTHER, 'other')
     ],
     'flourish_caregiver.generalsymptoms': [

--- a/flourish_caregiver/models/caregiver_tb_screening.py
+++ b/flourish_caregiver/models/caregiver_tb_screening.py
@@ -1,27 +1,48 @@
 from django.db import models
 from edc_base.model_mixins import BaseUuidModel
-from edc_constants.choices import YES_NO
 
+from flourish_caregiver.choices import YES_NO_AR_OTHER
 from flourish_caregiver.helper_classes import MaternalStatusHelper
 from flourish_caregiver.helper_classes.tb_diagnosis import TBDiagnosis
 from flourish_caregiver.models.model_mixins import CrfModelMixin
 from flourish_caregiver.models.model_mixins.flourish_tb_screening_mixin import \
     TBScreeningMixin
+from flourish_child.choices import YES_NO_OTHER
 
 
 class CaregiverTBScreening(CrfModelMixin, TBScreeningMixin):
     diagnosed_with_TB = models.CharField(
         verbose_name='Were you diagnosed with TB?',
-        choices=YES_NO,
-        max_length=25)
+        choices=YES_NO_AR_OTHER,
+        max_length=25,
+        blank=True,
+        null=True
+    )
+    diagnosed_with_TB_other = models.TextField(
+        verbose_name='If Other, please specify',
+        blank=True, null=True)
+
     started_on_TB_treatment = models.CharField(
         verbose_name='Were you started on TB treatment?',
-        choices=YES_NO,
-        max_length=3)
+        choices=YES_NO_OTHER,
+        max_length=15,
+        blank=True,
+        null=True)
+
+    started_on_TB_treatment_other = models.TextField(
+        verbose_name='If Other, please specify',
+        blank=True, null=True)
+
     started_on_TB_preventative_therapy = models.CharField(
         verbose_name='Were you started on TB preventative therapy?',
-        choices=YES_NO,
-        max_length=3)
+        choices=YES_NO_OTHER,
+        max_length=15,
+        blank=True,
+        null=True)
+
+    started_on_TB_preventative_therapy_other = models.TextField(
+        verbose_name='If Other, please specify',
+        blank=True, null=True)
 
     def save(self, *args, **kwargs):
         maternal_status_helper = MaternalStatusHelper(maternal_visit=self.maternal_visit)

--- a/flourish_caregiver/models/model_mixins/flourish_tb_screening_mixin.py
+++ b/flourish_caregiver/models/model_mixins/flourish_tb_screening_mixin.py
@@ -49,8 +49,8 @@ class TBScreeningMixin(models.Model):
         max_length=10, blank=True, null=True)
 
     household_diagnosed_with_tb = models.CharField(
-        verbose_name='Since the last time you spoke with FLOURISH staff, have you been '
-                     'evaluated in a clinic for TB?',
+        verbose_name='Since the last time you spoke with FLOURISH staff, has someone in '
+                     'your household been diagnosed with TB? ',
         choices=YES_NO_UKN_CHOICES,
         max_length=20, )
 


### PR DESCRIPTION
The code has been updated to improve clarity and integrity. In list_data.py, the 'None' constant is now correctly represented as NONE. In choices.py, a new constant tuple YES_NO_AR_OTHER has been added. Lastly, in flourish_tb_screening_mixin.py, the prompt for 'household_diagnosed_with_tb' has been changed to mention the diagnosis of TB in the household, instead of the evaluation of TB in a clinic.