### PR TITLE
(refactor): Simplify code in caregiver predicates


### DIFF
--- a/flourish_caregiver/tests/test_childhood_lead_exposure_risk.py
+++ b/flourish_caregiver/tests/test_childhood_lead_exposure_risk.py
@@ -93,11 +93,16 @@ class TestChildhoodLeadExposureRisk(TestCase):
             report_datetime=get_utcnow(),
             reason=SCHEDULED)
 
+        ap = Appointment.objects.get(
+            visit_code='2001M',
+            subject_identifier=self.subject_consent.subject_identifier)
+
+        ap.appt_datetime = get_utcnow()
+        ap.save()
+
         mommy.make_recipe(
             'flourish_caregiver.maternalvisit',
-            appointment=Appointment.objects.get(
-                visit_code='2001M',
-                subject_identifier=self.subject_consent.subject_identifier),
+            appointment=ap,
             report_datetime=get_utcnow(),
             reason=SCHEDULED)
 
@@ -160,6 +165,8 @@ class TestChildhoodLeadExposureRisk(TestCase):
             maternal_visit=visit
         )
 
+        breakpoint()
+
         mommy.make_recipe(
             'flourish_caregiver.maternalvisit',
             appointment=Appointment.objects.get(
@@ -175,7 +182,6 @@ class TestChildhoodLeadExposureRisk(TestCase):
 
     @tag('ryl')
     def test_required_year_later(self, ):
-
         visit = mommy.make_recipe(
             'flourish_caregiver.maternalvisit',
             appointment=Appointment.objects.get(

--- a/flourish_caregiver/tests/test_childhood_lead_exposure_risk.py
+++ b/flourish_caregiver/tests/test_childhood_lead_exposure_risk.py
@@ -165,7 +165,6 @@ class TestChildhoodLeadExposureRisk(TestCase):
             maternal_visit=visit
         )
 
-        breakpoint()
 
         mommy.make_recipe(
             'flourish_caregiver.maternalvisit',


### PR DESCRIPTION

The code in caregiver_predicates.py underwent significant simplification. Unnecessary helper functions for fetching subject schedules and schedule names were removed and replaced with direct function calls from the helper_classes.utils module. This results in a cleaner function for checking childhood lead exposure risk. Signed-off-by: nmunatsibw 