### PR TITLE
(Update) Add conditional fieldlists property and update model field options



### DIFF
--- a/flourish_caregiver/admin/caregiver_tb_screening_admin.py
+++ b/flourish_caregiver/admin/caregiver_tb_screening_admin.py
@@ -73,5 +73,9 @@ class CaregiverTBScreeningAdmin(CrfModelAdminMixin, PreviousResultsAdminMixin,
 
     filter_horizontal = ('tb_tests',)
 
+    @property
+    def conditional_fieldlists(self):
+        return self.get_previous_results_conditional_fieldlists({})
+
     def get_keys(self, request, obj=None):
         return self.get_previous_results_keys(request, obj)

--- a/flourish_caregiver/models/model_mixins/flourish_tb_screening_mixin.py
+++ b/flourish_caregiver/models/model_mixins/flourish_tb_screening_mixin.py
@@ -58,7 +58,8 @@ class TBScreeningMixin(models.Model):
         verbose_name='Since the last time you spoke with FLOURISH staff, have you been '
                      'evaluated in a clinic for TB?',
         choices=YES_NO_UKN_CHOICES,
-        help_text='Only for children',
+        blank=True,
+        null=True,
         max_length=20, )
 
     clinic_visit_date = models.DateField(


### PR DESCRIPTION
A new `conditional_fieldlists` property has been added to the Caregiver TB Screening admin for better accessibility. The options for the field `clinic_visit_date` in the Caregiver TB Screening model have also been updated to allow blank and null entries, improving data flexibility. Signed-off-by: nmunatsibw