### PR TITLE
(update): Clarify verbose names in lead exposure model



### DIFF
--- a/flourish_caregiver/models/childhood_lead_exposure_risk.py
+++ b/flourish_caregiver/models/childhood_lead_exposure_risk.py
@@ -17,7 +17,8 @@ class ChildhoodLeadExposureRisk(CrfModelMixin):
     )
 
     lead_exposure_test = models.CharField(
-        verbose_name='Has your child ever been tested for lead exposure?',
+        verbose_name='Has your child ever been tested for lead exposure (do not include '
+                     'any FLOURISH study lab activities)?',
         max_length=7,
         choices=YES_NO,
     )
@@ -128,7 +129,8 @@ class ChildhoodLeadExposureRisk(CrfModelMixin):
     )
 
     pr_male_caregiver_edu = models.CharField(
-        verbose_name='Education level of primary male caregiver',
+        verbose_name='Education level of primary male caregiver of the child (Male '
+                     'caregiver is not required to be biological father)',
         max_length=45,
         choices=CAREGIVER_EDUCATION_LEVEL_CHOICES
     )


### PR DESCRIPTION
Two verbose names in the childhood lead exposure risk model were updated for better clarity. The changes specify the context for lead exposure testing and the definition of the male caregiver. Signed-off-by: nmunatsibw 