### PR TITLE
(update): Add ParentAdolReloScaleParentModel



### DIFF
--- a/flourish_caregiver/admin/__init__.py
+++ b/flourish_caregiver/admin/__init__.py
@@ -68,7 +68,7 @@ from .medical_history_admin import MedicalHistoryAdmin
 from .modeladmin_mixins import VersionControlMixin
 from .obsterical_history_admin import ObstericalHistoryAdmin
 from .offschedule_admin import CaregiverOffScheduleAdmin
-from .parent_adol_relationship_scale_admin import ParentAdolRelationshipScaleAdmin
+from .parent_adol_relationship_scale_admin import ParentAdolRelationshipScaleParentAdmin
 from .post_hiv_rapid_testing_and_conseling_admin import PostHivRapidTestAndConselingAdmin
 from .relationship_father_involvement_admin import RelationshipFatherInvolvementAdmin
 from .screening_preg_women_admin import (ScreeningPregWomenAdmin,
@@ -97,4 +97,3 @@ from .tb_screen_preg_admin import TbScreenPregAdmin
 from .tb_study_screening_admin import TbStudyEligibilityAdmin
 from .tb_visit_screening_women_admin import TbVisitScreeningWomenAdmin
 from .ultrasound_admin import UltraSoundAdmin
-from .parent_adol_relationship_scale_admin import ParentAdolRelationshipScaleAdmin

--- a/flourish_caregiver/admin/parent_adol_relationship_scale_admin.py
+++ b/flourish_caregiver/admin/parent_adol_relationship_scale_admin.py
@@ -115,9 +115,9 @@ class ParentAdolRelationshipScaleAdmin(StackedInlineMixin,
 
     def check_sibship(self, subject_ident, child_subject_identifier):
         suffix = child_subject_identifier.split('-')[-1]
-        kids = self.consent_cls.objects.filter(
+        kids = list(set(self.consent_cls.objects.filter(
             subject_consent__subject_identifier=subject_ident).values_list(
-            'subject_identifier', flat=True)
+            'subject_identifier', flat=True)))
         if self.determine_sibship(suffix) in ['Twin', 'Triplet']:
             return [kid for kid in kids if
                     self.determine_sibship(kid.split('-')[-1]) in ['Twin', 'Triplet']]

--- a/flourish_caregiver/forms/__init__.py
+++ b/flourish_caregiver/forms/__init__.py
@@ -32,6 +32,7 @@ from .caregiver_previously_enrolled_form import CaregiverPreviouslyEnrolledForm
 from .caregiver_requisition_form import CaregiverRequisitionForm
 from .caregiver_requisition_result_form import CaregiverRequisitionResultForm
 from .caregiver_safi_stigma_form import CaregiverSafiStigmaForm
+from .caregiver_safi_stigma_form import CaregiverSafiStigmaForm
 from .caregiver_social_work_referral_form import CaregiverSocialWorkReferralForm
 from .caregiver_tb_referral_form import CaregiverTBReferralForm
 from .caregiver_tb_referral_outcome_form import CaregiverTBReferralOutcomeForm
@@ -67,7 +68,8 @@ from .maternal_visit_form import MaternalVisitFormValidator
 from .medical_history_form import MedicalHistoryForm
 from .obsterical_history_form import ObstericalHistoryForm
 from .offschedule_form import CaregiverOffScheduleForm
-from .parent_adol_relationship_scale_forms import ParentAdolRelationshipScaleForm
+from .parent_adol_relationship_scale_forms import ParentAdolRelationshipScaleForm, \
+    ParentAdolRelationshipScaleParentForm
 from .post_hiv_rapid_testing_and_conseling_form import PostHivRapidTestAndConselingForm
 from .relationship_father_involvement_form import RelationshipFatherInvolvementForm
 from .screening_preg_women_form import ScreeningPregWomenForm, \
@@ -98,5 +100,3 @@ from .tb_screen_preg_form import TbScreenPregForm
 from .tb_study_screening_form import TbStudyScreeningForm
 from .tb_visit_screening_women_form import TbVisitScreeningWomenForm
 from .ultrasound_form import UltraSoundForm
-from .caregiver_safi_stigma_form import CaregiverSafiStigmaForm
-from .parent_adol_relationship_scale_forms import ParentAdolRelationshipScaleForm

--- a/flourish_caregiver/forms/parent_adol_relationship_scale_forms.py
+++ b/flourish_caregiver/forms/parent_adol_relationship_scale_forms.py
@@ -1,9 +1,16 @@
 from django import forms
-from .form_mixins import SubjectModelFormMixin
-from ..models import ParentAdolRelationshipScale
+
+from .form_mixins import InlineSubjectModelFormMixin, SubjectModelFormMixin
+from ..models import ParentAdolRelationshipScale, ParentAdolReloScaleParentModel
 
 
-class ParentAdolRelationshipScaleForm(SubjectModelFormMixin, forms.ModelForm):
+class ParentAdolRelationshipScaleForm(InlineSubjectModelFormMixin):
     class Meta:
         model = ParentAdolRelationshipScale
+        fields = '__all__'
+
+
+class ParentAdolRelationshipScaleParentForm(SubjectModelFormMixin, forms.ModelForm):
+    class Meta:
+        model = ParentAdolReloScaleParentModel
         fields = '__all__'

--- a/flourish_caregiver/models/__init__.py
+++ b/flourish_caregiver/models/__init__.py
@@ -82,7 +82,8 @@ from .onschedule import OnScheduleCohortASecSeq, OnScheduleCohortBSecSeq, \
 from .onschedule import OnScheduleCohortATb2Months, OnScheduleCohortATb6Months
 from .onschedule import OnScheduleCohortBFUQuarterly, OnScheduleCohortCFUQuarterly
 from .onschedule import OnScheduleCohortBQuarterly, OnScheduleCohortCEnrollment
-from .parent_adol_relationship_scale import ParentAdolRelationshipScale
+from .parent_adol_relationship_scale import ParentAdolRelationshipScale, \
+    ParentAdolReloScaleParentModel
 from .post_hiv_rapid_testing_and_conseling import PostHivRapidTestAndConseling
 from .relationship_father_involvement import RelationshipFatherInvolvement
 from .screening_preg_women import ScreeningPregWomen, ScreeningPregWomenInline
@@ -117,5 +118,3 @@ from .tb_screen_preg import TbScreenPreg
 from .tb_study_screening import TbStudyEligibility
 from .tb_visit_screening_women import TbVisitScreeningWomen
 from .ultrasound import UltraSound
-from .caregiver_safi_stigma import CaregiverSafiStigma
-from .parent_adol_relationship_scale import ParentAdolRelationshipScale

--- a/flourish_caregiver/models/parent_adol_relationship_scale.py
+++ b/flourish_caregiver/models/parent_adol_relationship_scale.py
@@ -1,9 +1,25 @@
 from django.db import models
+from django.db.models import PROTECT
+from edc_base.model_mixins import BaseUuidModel
+from edc_visit_tracking.model_mixins import CrfInlineModelMixin
+
 from .model_mixins import CrfModelMixin
 from ..choices import RELATIONSHIP_SCALE
 
 
-class ParentAdolRelationshipScale(CrfModelMixin):
+class ParentAdolReloScaleParentModel(CrfModelMixin):
+    class Meta:
+        app_label = 'flourish_caregiver'
+        verbose_name = 'Parent-Adolescent Relationship Scales'
+
+
+class ParentAdolRelationshipScale(CrfInlineModelMixin, BaseUuidModel):
+    parent_adol_relo_scale_parent_model = models.ForeignKey(
+        ParentAdolReloScaleParentModel, on_delete=PROTECT, null=True)
+
+    associated_child_identifier = models.CharField(
+        max_length=25)
+
     eat_together = models.CharField(
         verbose_name="We eat meals together",
         max_length=2,
@@ -41,7 +57,8 @@ class ParentAdolRelationshipScale(CrfModelMixin):
         choices=RELATIONSHIP_SCALE)
 
     compassion = models.CharField(
-        verbose_name='During stressful times in my child/adolescents life, I check if he/she is okay',
+        verbose_name='During stressful times in my child/adolescents life, I check if '
+                     'he/she is okay',
         max_length=2,
         choices=RELATIONSHIP_SCALE)
 
@@ -51,7 +68,8 @@ class ParentAdolRelationshipScale(CrfModelMixin):
         choices=RELATIONSHIP_SCALE)
 
     play_sport = models.CharField(
-        verbose_name='I play sport or do other physical activities with my child/adolescent',
+        verbose_name='I play sport or do other physical activities with my '
+                     'child/adolescent',
         max_length=2,
         choices=RELATIONSHIP_SCALE)
 
@@ -61,7 +79,8 @@ class ParentAdolRelationshipScale(CrfModelMixin):
         choices=RELATIONSHIP_SCALE)
 
     encourage = models.CharField(
-        verbose_name='I encourage my child/adolescent to do things he/she is interested in or enjoys',
+        verbose_name='I encourage my child/adolescent to do things he/she is interested '
+                     'in or enjoys',
         max_length=2,
         choices=RELATIONSHIP_SCALE)
 
@@ -76,7 +95,8 @@ class ParentAdolRelationshipScale(CrfModelMixin):
         choices=RELATIONSHIP_SCALE)
 
     encourage_expression = models.CharField(
-        verbose_name='I encourage my child/adolescent to talk about their thoughts and feelings',
+        verbose_name='I encourage my child/adolescent to talk about their thoughts and '
+                     'feelings',
         max_length=2,
         choices=RELATIONSHIP_SCALE)
 
@@ -89,7 +109,7 @@ class ParentAdolRelationshipScale(CrfModelMixin):
         question_3 = int(self.family_events_together)
         question_10 = int(self.play_sport)
 
-        result =  (question_1 + question_2 + question_3 + question_10) / 4
+        result = (question_1 + question_2 + question_3 + question_10) / 4
 
         return round(result, 4)
 
@@ -104,9 +124,9 @@ class ParentAdolRelationshipScale(CrfModelMixin):
         question_12 = int(self.encourage)
         question_15 = int(self.encourage_expression)
 
-        result =  (question_4 + question_5 + question_6 + 
-                question_8 + question_12 + question_15) / 6
-        
+        result = (question_4 + question_5 + question_6 +
+                  question_8 + question_12 + question_15) / 6
+
         return round(result, 4)
 
     @property
@@ -119,7 +139,7 @@ class ParentAdolRelationshipScale(CrfModelMixin):
         question_11 = int(self.complains_about_me)
         question_13 = int(self.criticize_child)
         question_14 = int(self.change_attitude)
-        result =  (question_7 + question_9 + question_11 + question_13 + question_14) / 5
+        result = (question_7 + question_9 + question_11 + question_13 + question_14) / 5
 
         return round(result, 4)
 


### PR DESCRIPTION
Introduced ParentAdolReloScaleParentModel and associated forms, models, and admin configurations to support parent-adolescent relationship scales. These changes enhance the existing structure to include hierarchical relationships and additional functionality for managing parent-adolescent relationship data. Signed-off-by: nmunatsibw 