### PR TITLE
(update): Replace scale choices with yes/no/unknown options

### DIFF
--- a/flourish_caregiver/choices.py
+++ b/flourish_caregiver/choices.py
@@ -1342,11 +1342,8 @@ RELATIONSHIP_SCALE = (
     ('5', '5'),
 )
 
-RELATIONSHIP_SCALE = (
-    ('0', '0'),
-    ('1', '1'),
-    ('2', '2'),
-    ('3', '3'),
-    ('4', '4'),
-    ('5', '5'),
+YES_NO_UNK_NO_CHILD = (
+    (YES, YES),
+    (NO, NO),
+    (UNKNOWN, 'Unknown, Caregiver does not live with child'),
 )

--- a/flourish_caregiver/models/childhood_lead_exposure_risk.py
+++ b/flourish_caregiver/models/childhood_lead_exposure_risk.py
@@ -2,6 +2,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from edc_constants.choices import YES_NO
 
+from flourish_caregiver.choices import YES_NO_UNK_NO_CHILD
 from flourish_caregiver.models.model_mixins import CrfModelMixin
 from flourish_child.choices import (BUILT_DATES, BUSINESSES_RUN,
                                     CAREGIVER_EDUCATION_LEVEL_CHOICES)
@@ -108,15 +109,15 @@ class ChildhoodLeadExposureRisk(CrfModelMixin):
 
     peeling_paint = models.CharField(
         verbose_name='Is there any peeling, chipping or cracking paint in your home?',
-        max_length=7,
-        choices=YES_NO,
+        max_length=30,
+        choices=YES_NO_UNK_NO_CHILD,
     )
 
     house_by_busy_road = models.CharField(
         verbose_name='Since your child was born, have you ever lived in a home next to a '
                      'busy road',
-        max_length=7,
-        choices=YES_NO,
+        max_length=30,
+        choices=YES_NO_UNK_NO_CHILD,
     )
 
     years_near_busy_road = models.DecimalField(


### PR DESCRIPTION
The choice options for several fields in the child socio-demographic model have been updated. The YES_NO options have been replaced with YES_NO_UNK_NO_CHILD to allow for more comprehensive data capture. Signed-off-by: nmunatsibw 