### PR TITLE
(feature): Add read-only child identifier field

### DIFF
--- a/flourish_caregiver/forms/parent_adol_relationship_scale_forms.py
+++ b/flourish_caregiver/forms/parent_adol_relationship_scale_forms.py
@@ -5,6 +5,10 @@ from ..models import ParentAdolRelationshipScale, ParentAdolReloScaleParentModel
 
 
 class ParentAdolRelationshipScaleForm(InlineSubjectModelFormMixin):
+
+    associated_child_identifier = forms.CharField(
+        label='Associated child identifier',
+        widget=forms.TextInput(attrs={'readonly': 'readonly'}))
     class Meta:
         model = ParentAdolRelationshipScale
         fields = '__all__'

--- a/flourish_caregiver/forms/parent_adol_relationship_scale_forms.py
+++ b/flourish_caregiver/forms/parent_adol_relationship_scale_forms.py
@@ -5,10 +5,10 @@ from ..models import ParentAdolRelationshipScale, ParentAdolReloScaleParentModel
 
 
 class ParentAdolRelationshipScaleForm(InlineSubjectModelFormMixin):
-
     associated_child_identifier = forms.CharField(
         label='Associated child identifier',
         widget=forms.TextInput(attrs={'readonly': 'readonly'}))
+
     class Meta:
         model = ParentAdolRelationshipScale
         fields = '__all__'


### PR DESCRIPTION


A new field 'associated_child_identifier' was added to the ParentAdolRelationshipScaleForm. This field is a read-only text input, ensuring the child identifier cannot be modified. Signed-off-by: nmunatsibw 